### PR TITLE
Add contribution guidelines

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,110 @@
+************
+Contributing
+************
+
+Contributions are welcome, and they are greatly appreciated! Every
+little bit helps, and credit will always be given.
+
+You can contribute in many ways:
+
+Types of Contributions
+======================
+
+Report Bugs
+-----------
+
+Report bugs at the
+`GitHub issue tracker <https://github.com/transcode-de/durga/issues>`_.
+
+If you are reporting a bug, please include:
+
+* Your operating system name and version.
+* Any details about your local setup that might be helpful in troubleshooting.
+* Detailed steps to reproduce the bug.
+
+Fix Bugs
+--------
+
+Look through the GitHub issues for bugs. Anything tagged with "bug"
+is open to whoever wants to implement it.
+
+Implement Features
+------------------
+
+Look through the GitHub issues for features. Anything tagged with
+"feature" is open to whoever wants to implement it.
+
+Write Documentation
+-------------------
+
+Durga could always use more documentation, whether as part of the
+official Durga docs, in docstrings, or even on the web in blog posts,
+articles, and such.
+
+Submit Feedback
+---------------
+
+The best way to send feedback is to file an issue at the
+`GitHub issue tracker <https://github.com/transcode-de/durga/issues>`_.
+
+If you are proposing a feature:
+
+* Explain in detail how it would work.
+* Keep the scope as narrow as possible, to make it easier to implement.
+* Remember that this is a volunteer-driven project, and that
+  contributions are welcome :)
+
+Get Started!
+============
+
+Ready to contribute? Here's how to set up `durga` for local development.
+
+1. Fork the `durga` repo on GitHub.
+2. Clone your fork locally::
+
+    $ git clone git@github.com:your_name_here/durga.git
+
+3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
+
+    $ mkvirtualenv durga
+    $ cd durga
+    $ make develop
+
+4. Create a branch for local development::
+
+    $ git checkout -b name-of-your-bugfix-or-feature
+
+   Now you can make your changes locally.
+
+5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
+
+    $ make test
+    $ make test-all
+
+6. Commit your changes and push your branch to GitHub::
+
+    $ git add .
+    $ git commit -m "Your detailed description of your changes."
+    $ git push origin name-of-your-bugfix-or-feature
+
+7. Submit a pull request through the GitHub website.
+
+Pull Request Guidelines
+=======================
+
+Before you submit a pull request, check that it meets these guidelines:
+
+1. The pull request should include tests.
+2. If the pull request adds functionality, the docs should be updated. Put
+   your new functionality into a function with a docstring, and add the
+   feature to the list in `README.rst`.
+3. The pull request should work for Python 2.7 and 3.4. Check
+   `Travis CI <https://travis-ci.org/transcode-de/durga/pull_requests>`_
+   and make sure that the tests pass for all supported Python versions.
+
+Tips
+====
+
+To run a subset of tests::
+
+    $ make test TEST_ARGS='-k <EXPRESSION>'

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -76,10 +76,9 @@ Ready to contribute? Here's how to set up `cookiecutter-django-project` for loca
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
+5. When you're done making changes, check that your changes can build with cookiecutter and the created project tempate is working with Python 2 and Python 3::
 
-    $ make test
-    $ make test-all
+    $ tox
 
 6. Commit your changes and push your branch to GitHub::
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -68,7 +68,7 @@ Ready to contribute? Here's how to set up `cookiecutter-django-project` for loca
 
     $ mkvirtualenv cookiecutter-django-project
     $ cd cookiecutter-django-project
-    $ make develop
+    $ pip install -r requirements
 
 4. Create a branch for local development::
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -2,8 +2,8 @@
 Contributing
 ************
 
-Contributions are welcome, and they are greatly appreciated! Every
-little bit helps, and credit will always be given.
+Contributions are welcome, and they are greatly appreciated! Every little bit
+helps, and credit will always be given.
 
 You can contribute in many ways:
 
@@ -13,8 +13,8 @@ Types of Contributions
 Report Bugs
 -----------
 
-Report bugs at the
-`GitHub issue tracker <https://github.com/transcode-de/cookiecutter-django-project/issues>`_.
+Report bugs at the `GitHub issue tracker
+<https://github.com/transcode-de/cookiecutter-django-project/issues>`_.
 
 If you are reporting a bug, please include:
 
@@ -25,27 +25,27 @@ If you are reporting a bug, please include:
 Fix Bugs
 --------
 
-Look through the GitHub issues for bugs. Anything tagged with "bug"
-is open to whoever wants to implement it.
+Look through the GitHub issues for bugs. Anything tagged with "bug" is open to
+whoever wants to implement it.
 
 Implement Features
 ------------------
 
-Look through the GitHub issues for features. Anything tagged with
-"feature" is open to whoever wants to implement it.
+Look through the GitHub issues for features. Anything tagged with "feature" is
+open to whoever wants to implement it.
 
 Write Documentation
 -------------------
 
-Cookiecutter-django-project could always use more documentation, whether as part of the
-official cookiecutter-django-project docs, in docstrings, or even on the web in blog posts,
-articles, and such.
+cookiecutter-django-project could always use more documentation, whether as
+part of the official cookiecutter-django-project docs, in docstrings, or even
+on the web in blog posts, articles, and such.
 
 Submit Feedback
 ---------------
 
-The best way to send feedback is to file an issue at the
-`GitHub issue tracker <https://github.com/transcode-de/cookiecutter-django-project/issues>`_.
+The best way to send feedback is to file an issue at the `GitHub issue tracker
+<https://github.com/transcode-de/cookiecutter-django-project/issues>`_.
 
 If you are proposing a feature:
 
@@ -57,34 +57,49 @@ If you are proposing a feature:
 Get Started!
 ============
 
-Ready to contribute? Here's how to set up `cookiecutter-django-project` for local development.
+Ready to contribute? Here's how to set up `cookiecutter-django-project` for
+local development.
 
 1. Fork the `cookiecutter-django-project` repo on GitHub.
-2. Clone your fork locally::
+2. Clone your fork locally:
 
-    $ git clone git@github.com:your_name_here/cookiecutter-django-project.git
+   ::
 
-3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
+       $ git clone git@github.com:your_name_here/cookiecutter-django-project.git
 
-    $ mkvirtualenv cookiecutter-django-project
-    $ cd cookiecutter-django-project
-    $ pip install -r requirements
+3. Install your local copy into a virtualenv. Assuming you have
+   virtualenvwrapper installed, this is how you set up your fork for local
+   development:
 
-4. Create a branch for local development::
+   ::
 
-    $ git checkout -b name-of-your-bugfix-or-feature
+       $ mkvirtualenv cookiecutter-django-project
+       $ cd cookiecutter-django-project
+       $ pip install -r requirements
+
+4. Create a branch for local development:
+
+   ::
+
+       $ git checkout -b name-of-your-bugfix-or-feature
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes can build with cookiecutter and the created project tempate is working with Python 2 and Python 3::
+5. When you're done making changes, check that your changes can build with
+   cookiecutter and the created project template is working with Python 2 and
+   Python 3:
 
-    $ tox
+   ::
 
-6. Commit your changes and push your branch to GitHub::
+       $ tox
 
-    $ git add .
-    $ git commit -m "Your detailed description of your changes."
-    $ git push origin name-of-your-bugfix-or-feature
+6. Commit your changes and push your branch to GitHub:
+
+   ::
+
+       $ git add .
+       $ git commit -m "Your detailed description of your changes."
+       $ git push origin name-of-your-bugfix-or-feature
 
 7. Submit a pull request through the GitHub website.
 
@@ -104,6 +119,8 @@ Before you submit a pull request, check that it meets these guidelines:
 Tips
 ====
 
-To run a subset of tests::
+To run a subset of tests:
+
+::
 
     $ make test TEST_ARGS='-k <EXPRESSION>'

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -14,7 +14,7 @@ Report Bugs
 -----------
 
 Report bugs at the
-`GitHub issue tracker <https://github.com/transcode-de/durga/issues>`_.
+`GitHub issue tracker <https://github.com/transcode-de/cookiecutter-django-project/issues>`_.
 
 If you are reporting a bug, please include:
 
@@ -37,15 +37,15 @@ Look through the GitHub issues for features. Anything tagged with
 Write Documentation
 -------------------
 
-Durga could always use more documentation, whether as part of the
-official Durga docs, in docstrings, or even on the web in blog posts,
+Cookiecutter-django-project could always use more documentation, whether as part of the
+official cookiecutter-django-project docs, in docstrings, or even on the web in blog posts,
 articles, and such.
 
 Submit Feedback
 ---------------
 
 The best way to send feedback is to file an issue at the
-`GitHub issue tracker <https://github.com/transcode-de/durga/issues>`_.
+`GitHub issue tracker <https://github.com/transcode-de/cookiecutter-django-project/issues>`_.
 
 If you are proposing a feature:
 
@@ -57,17 +57,17 @@ If you are proposing a feature:
 Get Started!
 ============
 
-Ready to contribute? Here's how to set up `durga` for local development.
+Ready to contribute? Here's how to set up `cookiecutter-django-project` for local development.
 
-1. Fork the `durga` repo on GitHub.
+1. Fork the `cookiecutter-django-project` repo on GitHub.
 2. Clone your fork locally::
 
-    $ git clone git@github.com:your_name_here/durga.git
+    $ git clone git@github.com:your_name_here/cookiecutter-django-project.git
 
 3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
 
-    $ mkvirtualenv durga
-    $ cd durga
+    $ mkvirtualenv cookiecutter-django-project
+    $ cd cookiecutter-django-project
     $ make develop
 
 4. Create a branch for local development::
@@ -99,7 +99,7 @@ Before you submit a pull request, check that it meets these guidelines:
    your new functionality into a function with a docstring, and add the
    feature to the list in `README.rst`.
 3. The pull request should work for Python 2.7 and 3.4. Check
-   `Travis CI <https://travis-ci.org/transcode-de/durga/pull_requests>`_
+   `Travis CI <https://travis-ci.org/transcode-de/cookiecutter-django-project/pull_requests>`_
    and make sure that the tests pass for all supported Python versions.
 
 Tips

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,6 +3,7 @@
     "repo_name": "{{ cookiecutter.project_name|lower|replace(' ', '-') }}",
     "pkg_name": "{{ cookiecutter.repo_name|replace('-', '') }}",
     "author_name": "transcode",
+    "github_account": "transcode-de",
     "email": "noreply@example.com",
     "domain": "www.example.com",
     "description": "A short description of the project.",

--- a/{{ cookiecutter.repo_name }}/CONTRIBUTING.rst
+++ b/{{ cookiecutter.repo_name }}/CONTRIBUTING.rst
@@ -1,0 +1,110 @@
+************
+Contributing
+************
+
+Contributions are welcome, and they are greatly appreciated! Every
+little bit helps, and credit will always be given.
+
+You can contribute in many ways:
+
+Types of Contributions
+======================
+
+Report Bugs
+-----------
+
+Report bugs at the
+`GitHub issue tracker <https://github.com/transcode-de/durga/issues>`_.
+
+If you are reporting a bug, please include:
+
+* Your operating system name and version.
+* Any details about your local setup that might be helpful in troubleshooting.
+* Detailed steps to reproduce the bug.
+
+Fix Bugs
+--------
+
+Look through the GitHub issues for bugs. Anything tagged with "bug"
+is open to whoever wants to implement it.
+
+Implement Features
+------------------
+
+Look through the GitHub issues for features. Anything tagged with
+"feature" is open to whoever wants to implement it.
+
+Write Documentation
+-------------------
+
+Durga could always use more documentation, whether as part of the
+official Durga docs, in docstrings, or even on the web in blog posts,
+articles, and such.
+
+Submit Feedback
+---------------
+
+The best way to send feedback is to file an issue at the
+`GitHub issue tracker <https://github.com/transcode-de/durga/issues>`_.
+
+If you are proposing a feature:
+
+* Explain in detail how it would work.
+* Keep the scope as narrow as possible, to make it easier to implement.
+* Remember that this is a volunteer-driven project, and that
+  contributions are welcome :)
+
+Get Started!
+============
+
+Ready to contribute? Here's how to set up `durga` for local development.
+
+1. Fork the `durga` repo on GitHub.
+2. Clone your fork locally::
+
+    $ git clone git@github.com:your_name_here/durga.git
+
+3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
+
+    $ mkvirtualenv durga
+    $ cd durga
+    $ make develop
+
+4. Create a branch for local development::
+
+    $ git checkout -b name-of-your-bugfix-or-feature
+
+   Now you can make your changes locally.
+
+5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
+
+    $ make test
+    $ make test-all
+
+6. Commit your changes and push your branch to GitHub::
+
+    $ git add .
+    $ git commit -m "Your detailed description of your changes."
+    $ git push origin name-of-your-bugfix-or-feature
+
+7. Submit a pull request through the GitHub website.
+
+Pull Request Guidelines
+=======================
+
+Before you submit a pull request, check that it meets these guidelines:
+
+1. The pull request should include tests.
+2. If the pull request adds functionality, the docs should be updated. Put
+   your new functionality into a function with a docstring, and add the
+   feature to the list in `README.rst`.
+3. The pull request should work for Python 2.7 and 3.4. Check
+   `Travis CI <https://travis-ci.org/transcode-de/durga/pull_requests>`_
+   and make sure that the tests pass for all supported Python versions.
+
+Tips
+====
+
+To run a subset of tests::
+
+    $ make test TEST_ARGS='-k <EXPRESSION>'

--- a/{{ cookiecutter.repo_name }}/CONTRIBUTING.rst
+++ b/{{ cookiecutter.repo_name }}/CONTRIBUTING.rst
@@ -14,7 +14,7 @@ Report Bugs
 -----------
 
 Report bugs at the
-`GitHub issue tracker <https://github.com/transcode-de/{{ cookiecutter.repo_name }}/issues>`_.
+`GitHub issue tracker <https://github.com/{{ cookiecutter.github_account }}/{{ cookiecutter.repo_name }}/issues>`_.
 
 If you are reporting a bug, please include:
 
@@ -45,7 +45,7 @@ Submit Feedback
 ---------------
 
 The best way to send feedback is to file an issue at the
-`GitHub issue tracker <https://github.com/transcode-de/{{ cookiecutter.repo_name }}/issues>`_.
+`GitHub issue tracker <https://github.com/{{ cookiecutter.github_account }}/{{ cookiecutter.repo_name }}/issues>`_.
 
 If you are proposing a feature:
 
@@ -99,7 +99,7 @@ Before you submit a pull request, check that it meets these guidelines:
    your new functionality into a function with a docstring, and add the
    feature to the list in `README.rst`.
 3. The pull request should work for Python 2.7 and 3.4. Check
-   `Travis CI <https://travis-ci.org/transcode-de/{{ cookiecutter.repo_name }}/pull_requests>`_
+   `Travis CI <https://travis-ci.org/{{ cookiecutter.github_account }}/{{ cookiecutter.repo_name }}/pull_requests>`_
    and make sure that the tests pass for all supported Python versions.
 
 Tips

--- a/{{ cookiecutter.repo_name }}/CONTRIBUTING.rst
+++ b/{{ cookiecutter.repo_name }}/CONTRIBUTING.rst
@@ -14,7 +14,7 @@ Report Bugs
 -----------
 
 Report bugs at the
-`GitHub issue tracker <https://github.com/transcode-de/durga/issues>`_.
+`GitHub issue tracker <https://github.com/transcode-de/{{ cookiecutter.repo_name }}/issues>`_.
 
 If you are reporting a bug, please include:
 
@@ -37,15 +37,15 @@ Look through the GitHub issues for features. Anything tagged with
 Write Documentation
 -------------------
 
-Durga could always use more documentation, whether as part of the
-official Durga docs, in docstrings, or even on the web in blog posts,
+{{ cookiecutter.repo_name }} could always use more documentation, whether as part of the
+official {{ cookiecutter.repo_name }} docs, in docstrings, or even on the web in blog posts,
 articles, and such.
 
 Submit Feedback
 ---------------
 
 The best way to send feedback is to file an issue at the
-`GitHub issue tracker <https://github.com/transcode-de/durga/issues>`_.
+`GitHub issue tracker <https://github.com/transcode-de/{{ cookiecutter.repo_name }}/issues>`_.
 
 If you are proposing a feature:
 
@@ -57,17 +57,17 @@ If you are proposing a feature:
 Get Started!
 ============
 
-Ready to contribute? Here's how to set up `durga` for local development.
+Ready to contribute? Here's how to set up `{{ cookiecutter.repo_name }}` for local development.
 
-1. Fork the `durga` repo on GitHub.
+1. Fork the `{{ cookiecutter.repo_name }}` repo on GitHub.
 2. Clone your fork locally::
 
-    $ git clone git@github.com:your_name_here/durga.git
+    $ git clone git@github.com:your_name_here/{{ cookiecutter.repo_name }}.git
 
 3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
 
-    $ mkvirtualenv durga
-    $ cd durga
+    $ mkvirtualenv {{ cookiecutter.repo_name }}
+    $ cd {{ cookiecutter.repo_name }}
     $ make develop
 
 4. Create a branch for local development::
@@ -99,7 +99,7 @@ Before you submit a pull request, check that it meets these guidelines:
    your new functionality into a function with a docstring, and add the
    feature to the list in `README.rst`.
 3. The pull request should work for Python 2.7 and 3.4. Check
-   `Travis CI <https://travis-ci.org/transcode-de/durga/pull_requests>`_
+   `Travis CI <https://travis-ci.org/transcode-de/{{ cookiecutter.repo_name }}/pull_requests>`_
    and make sure that the tests pass for all supported Python versions.
 
 Tips

--- a/{{ cookiecutter.repo_name }}/CONTRIBUTING.rst
+++ b/{{ cookiecutter.repo_name }}/CONTRIBUTING.rst
@@ -2,8 +2,8 @@
 Contributing
 ************
 
-Contributions are welcome, and they are greatly appreciated! Every
-little bit helps, and credit will always be given.
+Contributions are welcome, and they are greatly appreciated! Every little bit
+helps, and credit will always be given.
 
 You can contribute in many ways:
 
@@ -13,8 +13,8 @@ Types of Contributions
 Report Bugs
 -----------
 
-Report bugs at the
-`GitHub issue tracker <https://github.com/{{ cookiecutter.github_account }}/{{ cookiecutter.repo_name }}/issues>`_.
+Report bugs at the `GitHub issue tracker
+<https://github.com/{{ cookiecutter.github_account }}/{{ cookiecutter.repo_name }}/issues>`_.
 
 If you are reporting a bug, please include:
 
@@ -25,27 +25,27 @@ If you are reporting a bug, please include:
 Fix Bugs
 --------
 
-Look through the GitHub issues for bugs. Anything tagged with "bug"
-is open to whoever wants to implement it.
+Look through the GitHub issues for bugs. Anything tagged with "bug" is open to
+whoever wants to implement it.
 
 Implement Features
 ------------------
 
-Look through the GitHub issues for features. Anything tagged with
-"feature" is open to whoever wants to implement it.
+Look through the GitHub issues for features. Anything tagged with "feature" is
+open to whoever wants to implement it.
 
 Write Documentation
 -------------------
 
-{{ cookiecutter.repo_name }} could always use more documentation, whether as part of the
-official {{ cookiecutter.repo_name }} docs, in docstrings, or even on the web in blog posts,
-articles, and such.
+{{ cookiecutter.repo_name }} could always use more documentation, whether as
+part of the official {{ cookiecutter.repo_name }} docs, in docstrings, or even
+on the web in blog posts, articles, and such.
 
 Submit Feedback
 ---------------
 
-The best way to send feedback is to file an issue at the
-`GitHub issue tracker <https://github.com/{{ cookiecutter.github_account }}/{{ cookiecutter.repo_name }}/issues>`_.
+The best way to send feedback is to file an issue at the `GitHub issue tracker
+<https://github.com/{{ cookiecutter.github_account }}/{{ cookiecutter.repo_name }}/issues>`_.
 
 If you are proposing a feature:
 
@@ -57,35 +57,47 @@ If you are proposing a feature:
 Get Started!
 ============
 
-Ready to contribute? Here's how to set up `{{ cookiecutter.repo_name }}` for local development.
+Ready to contribute? Here's how to set up `{{ cookiecutter.repo_name }}` for
+local development.
 
 1. Fork the `{{ cookiecutter.repo_name }}` repo on GitHub.
-2. Clone your fork locally::
+2. Clone your fork locally:
 
-    $ git clone git@github.com:your_name_here/{{ cookiecutter.repo_name }}.git
+   ::
 
-3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
+       $ git clone git@github.com:your_name_here/{{ cookiecutter.repo_name }}.git
 
-    $ mkvirtualenv {{ cookiecutter.repo_name }}
-    $ cd {{ cookiecutter.repo_name }}
-    $ make develop
+3. Install your local copy into a virtualenv. Assuming you have
+   virtualenvwrapper installed, this is how you set up your fork for local
+   development:
 
-4. Create a branch for local development::
+   ::
 
-    $ git checkout -b name-of-your-bugfix-or-feature
+       $ mkvirtualenv {{ cookiecutter.repo_name }}
+       $ cd {{ cookiecutter.repo_name }}
+       $ make develop
+
+4. Create a branch for local development:
+
+   ::
+
+       $ git checkout -b name-of-your-bugfix-or-feature
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
+5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox:
 
-    $ make test
-    $ make test-all
+   ::
 
-6. Commit your changes and push your branch to GitHub::
+       $ make test-all
 
-    $ git add .
-    $ git commit -m "Your detailed description of your changes."
-    $ git push origin name-of-your-bugfix-or-feature
+6. Commit your changes and push your branch to GitHub:
+
+   ::
+
+       $ git add .
+       $ git commit -m "Your detailed description of your changes."
+       $ git push origin name-of-your-bugfix-or-feature
 
 7. Submit a pull request through the GitHub website.
 
@@ -105,6 +117,8 @@ Before you submit a pull request, check that it meets these guidelines:
 Tips
 ====
 
-To run a subset of tests::
+To run a subset of tests:
+
+::
 
     $ make test TEST_ARGS='-k <EXPRESSION>'

--- a/{{ cookiecutter.repo_name }}/docs/contributing.rst
+++ b/{{ cookiecutter.repo_name }}/docs/contributing.rst
@@ -1,0 +1,1 @@
+.. include:: ../CONTRIBUTING.rst


### PR DESCRIPTION
The are two guidelines:
1. for cookiecutter-django-project itself
2. for project that is created with cookiecutter

Fixes #41.
