### PR TITLE
Add pep257

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,7 @@ Testing
 * `flake8 <https://gitlab.com/pycqa/flake8>`_
 * `freezegun <https://github.com/spulec/freezegun>`_
 * `isort <https://github.com/timothycrosley/isort>`_
+* `pep257 <https://github.com/GreenSteam/pep257>`_
 * `pytest <http://pytest.org/>`_
 * `pytest-django <http://pytest-django.readthedocs.org/>`_
 * `pytest-factoryboy <http://pytest-factoryboy.readthedocs.org/en/latest/>`_

--- a/{{ cookiecutter.repo_name }}/setup.cfg
+++ b/{{ cookiecutter.repo_name }}/setup.cfg
@@ -21,6 +21,10 @@ not_skip = __init__.py
 known_third_party = braces,configurations,coverage,crispy_forms,dj_database_url,django,envdir,factory_boy,freezegun,grappelli,psycopg2,pytest
 skip = manage.py,migrations,wsgi.py
 
+[pep257]
+add-ignore = D100,D104
+match-dir = (?!\.|bower_components|node_modules|migrations).*
+
 [pytest]
 DJANGO_SETTINGS_MODULE = {{ cookiecutter.pkg_name }}.config.settings.test
 DJANGO_CONFIGURATION = Test

--- a/{{ cookiecutter.repo_name }}/tests/conftest.py
+++ b/{{ cookiecutter.repo_name }}/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 
 @pytest.fixture
 def loaddata(settings, db):
-    """Loads a Django fixture.
+    """Load a Django fixture.
 
     Works exactly like the loaddata command. All command line options must be
     given as keyword arguments.

--- a/{{ cookiecutter.repo_name }}/tox.ini
+++ b/{{ cookiecutter.repo_name }}/tox.ini
@@ -33,6 +33,14 @@ deps =
     check-manifest==0.24
 skip_install = True
 
+[testenv:pep257]
+basepython = python3.5
+commands =
+    pep257 -s
+deps =
+    pep257==0.7.0
+skip_install = True
+
 [testenv:docs]
 basepython = python3.5
 commands =

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.pkg_name }}/config/settings/common.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.pkg_name }}/config/settings/common.py
@@ -13,39 +13,52 @@ class AdminsValue(values.SingleNestedTupleValue):
         1. The exact length of each tuple must be two.
         2. The second element of each tuple must be a valid email address.
     """
+
     def __init__(self, *args, **kwargs):
+        """Configure the value object and validate the default if present."""
         super(AdminsValue, self).__init__(*args, **kwargs)
         if self.default:
             self.validate(self.default)
 
     def validate_length(self, value):
+        """Validate that each tuple contains only two values."""
         if len(value) != 2:
             raise ValueError('Each ADMINS tuple must have exact two values')
 
     def validate_email(self, value):
+        """Validate the email address."""
         try:
             validate_email(value)
         except ValidationError:
             raise ValueError('Cannot interpret email value {0!r}'.format(value))
 
     def validate(self, value):
+        """Validate all tuples."""
         for item in value:
             self.validate_length(item)
             self.validate_email(item[1])
 
     def to_python(self, value):
+        """Convert environment variable string and validate the python objects."""
         value = super(AdminsValue, self).to_python(value)
         self.validate(value)
         return value
 
 
 class BaseDir(object):
-    # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+    """Provide absolute path to project package root directory as BASE_DIR setting.
+
+    Use it to build your absolute paths like this::
+
+        os.path.join(BaseDir.BASE_DIR, 'templates')
+    """
+
     BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 class Email(object):
     """Email settings for public projects."""
+
     EMAIL_HOST = values.Value('localhost')
     EMAIL_PORT = values.IntegerValue(25)  # Alternate TLS port is 587
     EMAIL_USE_TLS = values.BooleanValue(True)
@@ -54,6 +67,8 @@ class Email(object):
 
 
 class Common(Configuration):
+    """Common configuration base class."""
+
     SECRET_KEY = '(_j4e0=pbe(b+b1$^ch_48be0=gszglcgfzz^dy=(gnx=@m*b7'
 
     DEBUG = values.BooleanValue(False)
@@ -225,4 +240,5 @@ class Common(Configuration):
 
 class Public(Email, Common):
     """Settings for public projects."""
+
     SECRET_KEY = values.SecretValue()

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.pkg_name }}/config/settings/databases.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.pkg_name }}/config/settings/databases.py
@@ -4,6 +4,7 @@ from configurations import values
 
 class PostgreSQLDatabases(object):
     """Settings for local PostgreSQL databases."""
+
     DATABASES = {
         'default': dj_database_url.config(
             default='postgres://{{ cookiecutter.repo_name }}:{{ cookiecutter.repo_name }}@localhost/{{ cookiecutter.repo_name }}',  # noqa
@@ -17,6 +18,7 @@ class PostgreSQLDatabases(object):
 
 class EmptyDatabases(object):
     """Empty databases settings, used to force to overwrite them."""
+
     DATABASES = {
         'default': dj_database_url.config(env='DEFAULT_DATABASE_URL')
     }

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.pkg_name }}/config/settings/dev.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.pkg_name }}/config/settings/dev.py
@@ -31,6 +31,12 @@ class Dev(PostgreSQLDatabases, Common):
     # devserver must be ahead of django.contrib.staticfiles
     INSTALLED_APPS = ('devserver',) + Common.INSTALLED_APPS + ('debug_toolbar',)
 
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+        }
+    }
+
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
     @property

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.pkg_name }}/config/settings/dev.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.pkg_name }}/config/settings/dev.py
@@ -1,4 +1,5 @@
 import socket
+import subprocess
 
 from configurations import values
 
@@ -8,16 +9,24 @@ from .databases import PostgreSQLDatabases
 
 class Dev(PostgreSQLDatabases, Common):
     """Settings for development."""
-    def get_addr(self):
-        if socket.gethostname() == 'vagrant':
-            addr = socket.gethostbyname(socket.gethostname())
+
+    def get_client_ip(self):
+        """Return the client IP address.
+
+        Detect a Vagrant box by looking at the hostname. Return the gateway IP
+        on a Vagrant box, because this is the IP the request will originate
+        from.
+        """
+        if 'vagrant' in socket.gethostname():
+            addr = [line.split()[1] for line in subprocess.check_output(['netstat', '-rn']).splitlines() if line.startswith('0.0.0.0')][0]  # noqa
         else:
             addr = '127.0.0.1'
         return addr
 
     @property
     def INTERNAL_IPS(self):
-        return (self.get_addr(),)
+        """Return a tuple of IP addresses, as strings."""
+        return (self.get_client_ip(),)
 
     # devserver must be ahead of django.contrib.staticfiles
     INSTALLED_APPS = ('devserver',) + Common.INSTALLED_APPS + ('debug_toolbar',)
@@ -26,7 +35,8 @@ class Dev(PostgreSQLDatabases, Common):
 
     @property
     def DEVSERVER_DEFAULT_ADDR(self):
-        return self.get_addr()
+        """Return the default address to bind devserver to."""
+        return self.get_client_ip()
 
     DEVSERVER_ARGS = values.ListValue([])
 

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.pkg_name }}/config/settings/prod.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.pkg_name }}/config/settings/prod.py
@@ -4,4 +4,5 @@ from .databases import EmptyDatabases
 
 class Prod(EmptyDatabases, Public):
     """Settings for production server."""
+
     pass

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.pkg_name }}/config/settings/stage.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.pkg_name }}/config/settings/stage.py
@@ -4,4 +4,5 @@ from .databases import EmptyDatabases
 
 class Stage(EmptyDatabases, Public):
     """Settings for staging server."""
+
     pass

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.pkg_name }}/config/settings/test.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.pkg_name }}/config/settings/test.py
@@ -4,6 +4,7 @@ from .databases import PostgreSQLDatabases
 
 class Test(PostgreSQLDatabases, Common):
     """Settings for running the test suite."""
+
     # Use a fast hasher to speed up tests.
     PASSWORD_HASHERS = (
         'django.contrib.auth.hashers.MD5PasswordHasher',

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.pkg_name }}/context_processors.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.pkg_name }}/context_processors.py
@@ -2,5 +2,5 @@ import django
 
 
 def django_version(request):
-    """Adds the Django version to the context."""
+    """Add the Django version to the context."""
     return {'django_version': django.get_version()}


### PR DESCRIPTION
[pep257](https://github.com/GreenSteam/pep257) checks all docstrings to be compliant with [PEP 257](http://www.python.org/dev/peps/pep-0257/). As like for the other lint tools the checks are done in a tox env.

I also fixed the existing docstrings and added all missing docstrings.
