### PR TITLE
Include all python files with pep257

### DIFF
--- a/{{ cookiecutter.repo_name }}/MANIFEST.in
+++ b/{{ cookiecutter.repo_name }}/MANIFEST.in
@@ -6,6 +6,7 @@ include tox.ini
 
 exclude .bumpversion.cfg
 exclude .editorconfig
+exclude pep257.sh
 
 recursive-include docs *.rst .gitkeep conf.py Makefile make.bat
 recursive-include requirements *.pip

--- a/{{ cookiecutter.repo_name }}/pep257.sh
+++ b/{{ cookiecutter.repo_name }}/pep257.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+find . -name '*.py' -not -path './.*/*' -not -path '*/migrations/*' -not -path './node_modules/*' -exec pep257 -s {} +

--- a/{{ cookiecutter.repo_name }}/setup.cfg
+++ b/{{ cookiecutter.repo_name }}/setup.cfg
@@ -23,7 +23,6 @@ skip = manage.py,migrations,wsgi.py
 
 [pep257]
 add-ignore = D100,D104
-match-dir = (?!\.|bower_components|node_modules|migrations).*
 
 [pytest]
 DJANGO_SETTINGS_MODULE = {{ cookiecutter.pkg_name }}.config.settings.test

--- a/{{ cookiecutter.repo_name }}/tests/test_context_processors.py
+++ b/{{ cookiecutter.repo_name }}/tests/test_context_processors.py
@@ -4,4 +4,8 @@ from {{ cookiecutter.pkg_name }} import context_processors
 
 
 def test_django_version():
+    """Test the django_version context processor.
+
+    Must return a dictionary containing the current Django version.
+    """
     assert context_processors.django_version(None) == {'django_version': django.get_version()}

--- a/{{ cookiecutter.repo_name }}/tox.ini
+++ b/{{ cookiecutter.repo_name }}/tox.ini
@@ -39,7 +39,7 @@ skip_install = True
 [testenv:pep257]
 basepython = python3.5
 commands =
-    pep257 -s
+    {toxinidir}/pep257.sh
 deps =
     pep257==0.7.0
 skip_install = True


### PR DESCRIPTION
@keimlink: "The previous configuration for pep257did not check all Python files. Because find takes now care of excluding files the match-dir option for pep257 can be removed. ~~I didn't move bower_components to the exclude list for find because we won't use Bower for any future projects, just npm.~~"
