### PR TITLE
documentation: fixed releases.rst

### DIFF
--- a/{{ cookiecutter.repo_name }}/docs/releases.rst
+++ b/{{ cookiecutter.repo_name }}/docs/releases.rst
@@ -98,13 +98,13 @@ So create a new integration branch to merge ``master`` into ``develop``:
 
     $ git checkout -b merge-master-into-develop-for-release-1.0.0
 
-After that fetch the latest changes, rebase the integration branch and push
+After that fetch the latest changes, merge with the integration branch and push
 it:
 
 ::
 
     $ git fetch
-    $ git pull --rebase
+    $ git merge origin/develop
     $ git push --set-upstream origin merge-master-into-develop-for-release-1.0.0
 
 Now that we have the merge of ``master`` into ``develop`` in a separate


### PR DESCRIPTION
This pullrequest fixed a small issue in the releases.rst. The integration branch must not be rebased but merged with develop. Otherwise, during a new release, the release branch musst be merged with master to be able to push to github.
