### PR TITLE
Add settings to disable mails to admins

### DIFF
--- a/{{ cookiecutter.repo_name }}/docs/settings.rst
+++ b/{{ cookiecutter.repo_name }}/docs/settings.rst
@@ -105,6 +105,10 @@ List of general Django settings from
       - | A string representing the
         | language code for this
         | installation.
+    * - ``MAIL_ADMINS``
+      - ``False``
+      - No
+      - | Enables sending mails to admins.
     * - ``MIDDLEWARE_CLASSES``
       - | ``['django.contrib.sessions.middleware.SessionMiddleware',``
         | ``'django.middleware.common.CommonMiddleware',``

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.pkg_name }}/config/settings/common.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.pkg_name }}/config/settings/common.py
@@ -23,6 +23,8 @@ class Common(Configuration):
 
     DEBUG = values.BooleanValue(False)
 
+    MAIL_ADMINS = values.BooleanValue(False)
+
     ADMINS = AdminsValue(
         (('{{ cookiecutter.author_name }}', '{{ cookiecutter.error_email }}'),)
     )
@@ -38,6 +40,9 @@ class Common(Configuration):
             'require_debug_true': {
                 '()': 'django.utils.log.RequireDebugTrue',
             },
+           'require_mail_admins_true': {
+                '()': '{{ cookiecutter.pkg_name }}.config.settings.log.RequireMailAdminsTrue',
+            },
         },
         'handlers': {
             'console': {
@@ -50,7 +55,7 @@ class Common(Configuration):
             },
             'mail_admins': {
                 'level': 'ERROR',
-                'filters': ['require_debug_false'],
+                'filters': ['require_debug_false', 'require_mail_admins_true'],
                 'class': 'django.utils.log.AdminEmailHandler'
             }
         },

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.pkg_name }}/config/settings/common.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.pkg_name }}/config/settings/common.py
@@ -40,7 +40,7 @@ class Common(Configuration):
             'require_debug_true': {
                 '()': 'django.utils.log.RequireDebugTrue',
             },
-           'require_mail_admins_true': {
+            'require_mail_admins_true': {
                 '()': '{{ cookiecutter.pkg_name }}.config.settings.log.RequireMailAdminsTrue',
             },
         },

--- a/{{ cookiecutter.repo_name }}/{{ cookiecutter.pkg_name }}/config/settings/log.py
+++ b/{{ cookiecutter.repo_name }}/{{ cookiecutter.pkg_name }}/config/settings/log.py
@@ -1,0 +1,8 @@
+from django.conf import settings
+
+"""Filter functions for python logging framework."""
+
+
+def RequireMailAdminsTrue():
+    """Return MAIL_ADMINS setting."""
+    return settings.MAIL_ADMINS


### PR DESCRIPTION
I added a settings called `MAIL_ADMINS` which is per default `False`.
